### PR TITLE
Remove button within anchor for sign-in/ sign-out buttons

### DIFF
--- a/components/nav.js
+++ b/components/nav.js
@@ -19,9 +19,16 @@ export default () => {
         <p className={`nojs-show ${(!session && loading) ? styles.loading : styles.loaded}`}>
           {!session && <>
             <span className={styles.notSignedInText}>You are not signed in</span>
-            <a href={`/api/auth/signin`} onClick={(e) => { e.preventDefault(); signin() }}>
-              <button className={styles.buttonPrimary}>Sign in</button>
-            </a>
+            <a
+                href={`/api/auth/signin`}
+                className={styles.buttonPrimary}
+                onClick={(e) => {
+                  e.preventDefault();
+                  signin();
+                }}
+              >
+                Sign in
+              </a>
           </>}
           {session && <>
             <span style={{backgroundImage: `url(${session.user.image})` }} className={styles.avatar}/>
@@ -29,9 +36,16 @@ export default () => {
               <small>Signed in as</small><br/>
               <strong>{session.user.email || session.user.name}</strong>
               </span>
-            <a href={`/api/auth/signout`} onClick={(e) => { e.preventDefault(); signout() }}>
-              <button className={styles.button}>Sign out</button>
-            </a>
+            <a
+                href={`/api/auth/signout`}
+                className={styles.button}
+                onClick={(e) => {
+                  e.preventDefault();
+                  signout();
+                }}
+              >
+                Sign out
+              </a>
           </>}
         </p>
       </div>

--- a/components/nav.module.css
+++ b/components/nav.module.css
@@ -68,6 +68,7 @@
   background-color: #fff;
   border: 1px solid #ccc;
   color: #555;
+  text-decoration: none;
 }
 
 .button:hover {


### PR DESCRIPTION
My [latest e2e test commit](https://github.com/iaincollins/next-auth/pull/298/commits/1272ab9cdc2bf65fc756ba608d470a926db56999) adjusted a test to press the sign-in button rather than navigating directly to the API route to better simulate the end-user. However, trying to get the sign in button from an anchor tag with the text "Sign in" fails, because the "Sign in" text is wrapped within a button.

This PR removes the button element from both the "Sign in" and "Sign out" buttons so as not to hit this [invalid HTML](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element:transparent:~:text=Transparent%2C%20but%20there%20must%20be%20no,descendant%20with%20the%20tabindex%20attribute%20specified.). The existing button css was used to retain the button styling.